### PR TITLE
feat: expose exercise age group metadata

### DIFF
--- a/src/exercise/exercise-age-groups.spec.ts
+++ b/src/exercise/exercise-age-groups.spec.ts
@@ -1,0 +1,23 @@
+import { ExerciseAgeGroup } from '../graphql/graphqlTypes';
+import { exerciseAgeGroups } from './exercise-age-groups';
+
+describe('exerciseAgeGroups', () => {
+  it('contains every age group exactly once in display order', () => {
+    expect(exerciseAgeGroups.map(({ ageGroup }) => ageGroup)).toEqual(
+      Object.values(ExerciseAgeGroup),
+    );
+    expect(exerciseAgeGroups.map(({ order }) => order)).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+  });
+
+  it('provides the display name and grade range for every age group', () => {
+    expect(exerciseAgeGroups).toEqual([
+      expect.objectContaining({ name: 'Koala', gradeRange: '3-4' }),
+      expect.objectContaining({ name: 'Medvebocs', gradeRange: '5-6' }),
+      expect.objectContaining({ name: 'Kismedve', gradeRange: '7-8' }),
+      expect.objectContaining({ name: 'Nagymedve', gradeRange: '9-10' }),
+      expect.objectContaining({ name: 'Jegesmedve', gradeRange: '11-12' }),
+    ]);
+  });
+});

--- a/src/exercise/exercise-age-groups.ts
+++ b/src/exercise/exercise-age-groups.ts
@@ -1,0 +1,37 @@
+import {
+  ExerciseAgeGroup,
+  ExerciseAgeGroupMetadata,
+} from '../graphql/graphqlTypes';
+
+export const exerciseAgeGroups: ExerciseAgeGroupMetadata[] = [
+  {
+    ageGroup: ExerciseAgeGroup.KOALA,
+    name: 'Koala',
+    gradeRange: '3-4',
+    order: 1,
+  },
+  {
+    ageGroup: ExerciseAgeGroup.MEDVEBOCS,
+    name: 'Medvebocs',
+    gradeRange: '5-6',
+    order: 2,
+  },
+  {
+    ageGroup: ExerciseAgeGroup.KISMEDVE,
+    name: 'Kismedve',
+    gradeRange: '7-8',
+    order: 3,
+  },
+  {
+    ageGroup: ExerciseAgeGroup.NAGYMEDVE,
+    name: 'Nagymedve',
+    gradeRange: '9-10',
+    order: 4,
+  },
+  {
+    ageGroup: ExerciseAgeGroup.JEGESMEDVE,
+    name: 'Jegesmedve',
+    gradeRange: '11-12',
+    order: 5,
+  },
+];

--- a/src/exercise/exercise.graphql
+++ b/src/exercise/exercise.graphql
@@ -1,4 +1,5 @@
 type Query {
+  exerciseAgeGroups: [ExerciseAgeGroupMetadata!]!
   searchExercises(query: ExerciseSearchQuery): ExerciseSearchResult!
   exercises(
     take: Int!
@@ -8,6 +9,13 @@ type Query {
   ): [Exercise!]!
   exercisesCount: Int!
   exercise(id: ID!): Exercise
+}
+
+type ExerciseAgeGroupMetadata {
+  ageGroup: ExerciseAgeGroup!
+  name: String!
+  gradeRange: String!
+  order: Int!
 }
 
 type Mutation {

--- a/src/exercise/exercise.resolver.ts
+++ b/src/exercise/exercise.resolver.ts
@@ -28,6 +28,7 @@ import { ExerciseHistoryService } from '../exercise-history/exercise-history.ser
 import { ExerciseCommentService } from '../exercise-comment/exercise-comment.service';
 import { ExerciseGroupService } from '../exercise-group/exercise-group.service';
 import { hasRolesOrAdmin } from '../auth/hasRolesOrAdmin';
+import { exerciseAgeGroups } from './exercise-age-groups';
 
 @Resolver('Exercise')
 export class ExerciseResolver {
@@ -42,6 +43,11 @@ export class ExerciseResolver {
     private readonly userService: UserService,
     private readonly exerciseHistoryService: ExerciseHistoryService,
   ) {}
+
+  @Query('exerciseAgeGroups')
+  getExerciseAgeGroups() {
+    return exerciseAgeGroups;
+  }
 
   @Query('exercise')
   @UseGuards(RolesGuard)

--- a/src/graphql/graphqlTypes.ts
+++ b/src/graphql/graphqlTypes.ts
@@ -317,6 +317,9 @@ export interface IQuery {
     id: string,
   ): Nullable<ExerciseTag> | Promise<Nullable<ExerciseTag>>;
   flatExerciseTags(): ExerciseTag[] | Promise<ExerciseTag[]>;
+  exerciseAgeGroups():
+    | ExerciseAgeGroupMetadata[]
+    | Promise<ExerciseAgeGroupMetadata[]>;
   searchExercises(
     query?: Nullable<ExerciseSearchQuery>,
   ): ExerciseSearchResult | Promise<ExerciseSearchResult>;
@@ -451,6 +454,13 @@ export interface ExerciseTag {
   parent?: Nullable<ExerciseTag>;
   children: ExerciseTag[];
   exerciseCount: number;
+}
+
+export interface ExerciseAgeGroupMetadata {
+  ageGroup: ExerciseAgeGroup;
+  name: string;
+  gradeRange: string;
+  order: number;
 }
 
 export interface ExerciseSearchResult {

--- a/src/load-old-excel/load-old-excel.service.ts
+++ b/src/load-old-excel/load-old-excel.service.ts
@@ -156,8 +156,9 @@ export class LoadOldExcelService {
           }
         }
 
-        const { imgRes, failedToDownloadImage } =
-          await this.tryToDownloadImage(record);
+        const { imgRes, failedToDownloadImage } = await this.tryToDownloadImage(
+          record,
+        );
 
         const { createdByUser, contributors, notFoundUserNames } =
           await this.getExerciseUsersByExcelRecord(record);


### PR DESCRIPTION
Closed because the age-group display labels already live in the frontend. The newly displayed grade ranges will be kept alongside that existing frontend metadata, so no backend API change is needed.